### PR TITLE
fix(sec): upgrade org.springframework:spring-context to 5.2.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring.version>3.2.18.RELEASE</spring.version>
+        <spring.version>5.2.21</spring.version>
         <slf4j.version>1.7.36</slf4j.version>
         <mockito.version>4.8.0</mockito.version>
     </properties>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-context 3.2.18.RELEASE
- [CVE-2022-22968](https://www.oscs1024.com/hd/CVE-2022-22968)


### What did I do？
Upgrade org.springframework:spring-context from 3.2.18.RELEASE to 5.2.21 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS