### PR TITLE
Could com.alibaba.compileflow: compileflow: 1.3.0-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,18 +126,6 @@
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
-        <!--
-            JSR305 is already Dormant status, so SpotBugs does not release jsr305 jar file.
-            Please continue using findbugs’ one.
-            depend on spotbugs-annotations instead.
-            https://spotbugs.readthedocs.io/en/stable/migration.html
-        -->
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <version>4.7.2</version>
-            <optional>true</optional>
-        </dependency>
 
         <!-- spring libs -->
         <dependency>


### PR DESCRIPTION

![1](https://user-images.githubusercontent.com/126549527/223605313-4bdd5142-b9d4-45fe-82a6-2b69af29ff51.png)

Hi, I found that **_com.alibaba.compileflow: compileflow: 1.3.0-SNAPSHOT_**’s pom file introduced **_28_** dependencies. However, among them, **_2_** libraries (**_7%_** have not been used by your project), the redundant dependencies are listed below. 

More seriously, **_1_**  redundant libraries have not been maintained by developers for more than **_3_** years（outdated dependencies）. 

Reduce these unused dependencies can help prevent introducing bugs/vulnerabilities from outdated dependencies. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding), and validated that they have not been used by the client code.
 
This PR **_com.alibaba.compileflow: compileflow: 1.3.0-SNAPSHOT_** for removing the redundant dependencies have passed the tests.

Best regards

## Redundant dependencies
#### Redundant direct dependencies:
         com.github.spotbugs:spotbugs-annotations:4.7.2:compile [14 KB]
#### Redundant indirect dependencies:
         com.google.code.findbugs:jsr305:3.0.2:compile [19 KB]  

## Outdated dependencies
com.google.code.findbugs:jsr305:3.0.2 (**_2168_** days without maintenance) 
