### PR TITLE
fix(sec): upgrade org.springframework:spring-core to 5.2.19.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring.version>3.2.18.RELEASE</spring.version>
+        <spring.version>6.0.7</spring.version>
         <slf4j.version>1.7.36</slf4j.version>
         <mockito.version>4.8.0</mockito.version>
     </properties>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-core 3.2.18.RELEASE
- [CVE-2021-22060](https://www.oscs1024.com/hd/CVE-2021-22060)


### What did I do？
Upgrade org.springframework:spring-core from 3.2.18.RELEASE to 5.2.19.RELEASE for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS